### PR TITLE
Apply policy for eslint-plugin-import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4566,17 +4566,6 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
-    "fs-extra": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "^4.1.2",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      }
-    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "css-loader": "^0.28.4",
     "eslint": "4.9.0",
     "eslint-config-airbnb": "^15.1.0",
-    "eslint-plugin-import": "^2.7.0",
+    "eslint-plugin-import": "^2.15.0",
     "eslint-plugin-jsx-a11y": "5.1.1",
     "eslint-plugin-react": "^7.2.1",
     "extract-css-chunks-webpack-plugin": "^2.0.16",


### PR DESCRIPTION
Apply policy `npm-project-deps::eslint-plugin-import`:

_NPM dependencies_
```eslint-plugin-import (^2.15.0)```

---
<details>
  <summary><img src="https://images.atomist.com/logo/atomist-color-mark-small.png" height="20" valign="bottom"/>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:npm-project-deps::eslint-plugin-import=6e66edb19134ff79b7115777913cca4c25f6d17acfead65af142b6f55ff22fd7]</code>
</details>